### PR TITLE
remove minimumDef usage

### DIFF
--- a/fdb-streaming.cabal
+++ b/fdb-streaming.cabal
@@ -59,7 +59,7 @@ library
       ekg-core,
       clock,
       unliftio,
-      witherable,
+      witherable-class,
       time,
       safe,
       simple-logger,

--- a/src/FDBStreaming.hs
+++ b/src/FDBStreaming.hs
@@ -341,7 +341,7 @@ import FoundationDB.Versionstamp
     Versionstamp (CompleteVersionstamp),
     VersionstampCompleteness (Complete),
   )
-import Safe.Foldable (minimumMay)
+import Safe.Foldable (minimumMay, minimumNote)
 import System.Clock (Clock (Monotonic), diffTimeSpec, getTime, toNanoSecs)
 import qualified System.Metrics as Metrics
 import System.Metrics.Counter (Counter)
@@ -588,7 +588,8 @@ defaultWatermark topicsAndReaders wmSS = do
     chkptsF <- getCheckpoints parent rn
     return $
       flip fmap chkptsF \ckpts ->
-        (parent, fromMaybe minBound $ minimumMay ckpts)
+        (parent, minimumNote "No checkpoints found for topic. Does it have zero partitions?"
+                             ckpts)
   minCheckpoints <- for minCheckpointsF await
   parentWMsF <- for minCheckpoints \(parent, Topic.Checkpoint vs _) ->
     getWatermark (topicWatermarkSS parent) $ transactionV $ conservativeVS vs

--- a/src/FDBStreaming.hs
+++ b/src/FDBStreaming.hs
@@ -245,7 +245,7 @@ import Data.Sequence (Seq ())
 import qualified Data.Sequence as Seq
 import Data.Text.Encoding (decodeUtf8)
 import Data.Traversable (for)
-import Data.Witherable (catMaybes, witherM)
+import Data.Witherable.Class (catMaybes, witherM)
 import Data.Word (Word8, Word16, Word64)
 import qualified FDBStreaming.AggrTable as AT
 import FDBStreaming.JobConfig (JobConfig (JobConfig, defaultNumPartitions, jobConfigDB, jobConfigSS, leaseDuration, logLevel, msgsPerBatch, numPeriodicJobThreads, numStreamThreads, streamMetricsStore, defaultChunkSizeBytes), JobSubspace)

--- a/src/FDBStreaming/Stream/Internal.hs
+++ b/src/FDBStreaming/Stream/Internal.hs
@@ -22,7 +22,7 @@ import Data.ByteString (ByteString)
 import Data.Foldable (for_)
 import Data.Maybe (fromJust, isJust)
 import Data.Sequence (Seq ())
-import Data.Witherable (Filterable, mapMaybe)
+import Data.Witherable.Class (Filterable, mapMaybe)
 import Data.Word (Word16)
 import FDBStreaming.JobConfig (JobConfig (jobConfigSS), JobSubspace)
 import FDBStreaming.Topic


### PR DESCRIPTION
Fixes bug where watermark could advance prematurely at the beginning of processing.